### PR TITLE
Remove the "Apollo" word from the api

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,13 +19,11 @@ export function ApolloProvider<CacheShape = any>(props: {
   client: ApolloClient<CacheShape>;
 }): JSX.Element;
 
-export function useApolloClient<CacheShape = any>(): ApolloClient<
-  CacheShape
-> | null;
+export function useClient<CacheShape = any>(): ApolloClient<CacheShape> | null;
 
 type QueryHookOptions<TVariables> = Omit<QueryOptions<TVariables>, 'query'>;
 
-export function useApolloQuery<TData = any, TVariables = OperationVariables>(
+export function useQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options?: QueryHookOptions<TVariables>
 ): ApolloQueryResult<TData> & {
@@ -40,7 +38,7 @@ type MutationHookOptions<T, TVariables> = Omit<
   'mutation'
 >;
 
-export function useApolloMutation<T, TVariables = OperationVariables>(
+export function useMutation<T, TVariables = OperationVariables>(
   mutation: DocumentNode,
   options?: MutationHookOptions<T, TVariables>
 ): ((

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,11 @@ export function ApolloProvider({ children, client }) {
   );
 }
 
-export function useApolloClient() {
+export function useClient() {
   return useContext(ApolloContext);
 }
 
-export function useApolloQuery(
+export function useQuery(
   query,
   { variables, context: apolloContextOptions, ...restOptions } = {}
 ) {
@@ -80,8 +80,8 @@ export function useApolloQuery(
   return { ...helpers, ...result };
 }
 
-export function useApolloMutation(mutation, baseOptions) {
-  const client = useApolloClient();
+export function useMutation(mutation, baseOptions) {
+  const client = useClient();
   return localOptions =>
     client.mutate({ mutation, ...baseOptions, ...localOptions });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,11 @@ export function useClient() {
   return useContext(ApolloContext);
 }
 
+export function useApolloClient() {
+  console.warn('useApolloClient is deprecated, please use useClient');
+  return useClient();
+}
+
 export function useQuery(
   query,
   { variables, context: apolloContextOptions, ...restOptions } = {}
@@ -80,6 +85,11 @@ export function useQuery(
   return { ...helpers, ...result };
 }
 
+export function useApolloQuery(...args) {
+  console.warn('useApolloQuery is deprecated, please use useQuery');
+  return useQuery(...args);
+}
+
 export function useMutation(mutation, baseOptions) {
   const client = useClient();
   return localOptions =>
@@ -97,4 +107,9 @@ function objToKey(obj) {
     return result;
   }, {});
   return JSON.stringify(sortedObj);
+}
+
+export function useApolloMutation(...args) {
+  console.warn('useApolloMutation is deprecated, please use useMutation');
+  return useMutation(...args);
 }


### PR DESCRIPTION
Hooks renamed:

- `useApolloClient` -> `useClient`
- `useApolloQuery` -> `useQuery`
- `useApolloMutation` -> `useMutation`

Also, warning messages were created