### PR TITLE
feat(useQuery): Combine GraphQL errors in single ApolloError.

### DIFF
--- a/src/__tests__/getMarkupFromTree-test.tsx
+++ b/src/__tests__/getMarkupFromTree-test.tsx
@@ -1,10 +1,11 @@
 import ApolloClient from 'apollo-client';
-import { ApolloLink, Observable } from 'apollo-link';
+import { DocumentNode } from 'apollo-link';
 import { MockedResponse } from 'apollo-link-mock';
 import gql from 'graphql-tag';
 import * as React from 'react';
 import { renderToString } from 'react-dom/server';
 
+import { GraphQLError } from 'graphql';
 import { ApolloProvider } from '../ApolloContext';
 import createClient from '../__testutils__/createClient';
 import { getMarkupFromTree } from '../getMarkupFromTree';
@@ -32,26 +33,45 @@ interface UserQueryResult {
   currentUser: { firstName: string };
 }
 
+const GRAPQHL_ERROR_QUERY = gql`
+  query GrapqhlErrorQuery {
+    authorized
+  }
+`;
+
+const NETWORK_ERROR_QUERY = gql`
+  query NetworkErrorQuery {
+    isAuthorized
+  }
+`;
+
 const MOCKS: MockedResponse[] = [
   {
     request: { query: AUTH_QUERY },
     result: { data: { isAuthorized: true } },
   },
+
   {
     request: { query: USER_QUERY },
     result: { data: { currentUser: { firstName: 'James' } } },
   },
+
+  {
+    request: { query: GRAPQHL_ERROR_QUERY, variables: {} },
+    result: {
+      data: { __typename: 'Query' },
+      errors: [new GraphQLError('Simulating GraphQL error')],
+    },
+  },
+
+  {
+    error: new Error('Simulating network error'),
+    request: { query: NETWORK_ERROR_QUERY, variables: {} },
+  },
 ];
 
-const linkReturningError = new ApolloLink(
-  () =>
-    new Observable(observer => {
-      observer.error(new Error('Simulating network error'));
-    })
-);
-
-function createMockClient(link?: ApolloLink) {
-  return createClient({ link, mocks: MOCKS, addTypename: false });
+function createMockClient() {
+  return createClient({ mocks: MOCKS, addTypename: false });
 }
 
 function useAuthDetails(options?: QueryHookOptions<{}>) {
@@ -60,8 +80,12 @@ function useAuthDetails(options?: QueryHookOptions<{}>) {
   return Boolean(!loading && data && data.isAuthorized);
 }
 
-function UserDetails(props: QueryHookOptions<{}>) {
-  const { data, loading } = useQuery<UserQueryResult>(USER_QUERY, props);
+interface UserDetailsProps extends QueryHookOptions<{}> {
+  readonly query?: DocumentNode;
+}
+
+function UserDetails({ query = USER_QUERY, ...props }: UserDetailsProps) {
+  const { data, loading } = useQuery<UserQueryResult>(query, props);
 
   return (
     <>
@@ -76,7 +100,7 @@ function UserDetails(props: QueryHookOptions<{}>) {
   );
 }
 
-interface UserWrapperProps extends QueryHookOptions<{}> {
+interface UserWrapperProps extends UserDetailsProps {
   readonly client: ApolloClient<object>;
 }
 
@@ -219,14 +243,41 @@ describe.each([[true], [false]])(
       ).rejects.toBe(fooError);
     });
 
-    it('should handle errors thrown by queries', async () => {
-      const client = createMockClient(linkReturningError);
-      const tree = <UserDetailsWrapper client={client} suspend={suspend} />;
+    it('should handle network errors thrown by queries', async () => {
+      const client = createMockClient();
+      const tree = (
+        <UserDetailsWrapper
+          client={client}
+          suspend={suspend}
+          query={NETWORK_ERROR_QUERY}
+        />
+      );
 
       await expect(
         getMarkupFromTree({ tree, renderFunction: renderToString })
       ).rejects.toMatchInlineSnapshot(
         `[Error: Network error: Simulating network error]`
+      );
+
+      expect(renderToString(tree)).toMatchInlineSnapshot(
+        `"No Current User (failed)"`
+      );
+    });
+
+    it('should handle GraphQL errors thrown by queries', async () => {
+      const client = createMockClient();
+      const tree = (
+        <UserDetailsWrapper
+          client={client}
+          suspend={suspend}
+          query={GRAPQHL_ERROR_QUERY}
+        />
+      );
+
+      await expect(
+        getMarkupFromTree({ tree, renderFunction: renderToString })
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: GraphQL error: Simulating GraphQL error]`
       );
 
       expect(renderToString(tree)).toMatchInlineSnapshot(

--- a/src/__tests__/useQuery-test.tsx
+++ b/src/__tests__/useQuery-test.tsx
@@ -1,87 +1,17 @@
 import { ApolloClient } from 'apollo-client';
-import { ApolloLink, DocumentNode, Observable } from 'apollo-link';
+import { DocumentNode } from 'apollo-link';
+import { MockedResponse } from 'apollo-link-mock';
 import gql from 'graphql-tag';
 import { withProfiler } from 'jest-react-profiler';
-import React, { Fragment, Suspense, SuspenseProps } from 'react';
+import React, { Suspense, SuspenseProps } from 'react';
 import { cleanup, render } from 'react-testing-library';
 
+import { GraphQLError } from 'graphql';
 import { ApolloProvider, QueryHookOptions, useQuery } from '..';
 import createClient from '../__testutils__/createClient';
 import { SAMPLE_TASKS } from '../__testutils__/data';
 import flushEffectsAndWait from '../__testutils__/flushEffectsAndWait';
 import noop from '../__testutils__/noop';
-
-const TASKS_MOCKS = [
-  {
-    request: {
-      query: gql`
-        query TasksQuery {
-          tasks {
-            id
-            text
-            completed
-            __typename
-          }
-        }
-      `,
-      variables: {},
-    },
-    result: {
-      data: {
-        __typename: 'Query',
-        tasks: [...SAMPLE_TASKS],
-      },
-    },
-  },
-
-  {
-    request: {
-      query: gql`
-        query FilteredTasksQuery($completed: Boolean!) {
-          tasks(completed: $completed) {
-            id
-            text
-            completed
-            __typename
-          }
-        }
-      `,
-      variables: {
-        completed: true,
-      },
-    },
-    result: {
-      data: {
-        __typename: 'Query',
-        tasks: SAMPLE_TASKS.filter(task => task.completed),
-      },
-    },
-  },
-
-  {
-    request: {
-      query: gql`
-        query FilteredTasksQuery($completed: Boolean!) {
-          tasks(completed: $completed) {
-            id
-            text
-            completed
-            __typename
-          }
-        }
-      `,
-      variables: {
-        completed: false,
-      },
-    },
-    result: {
-      data: {
-        __typename: 'Query',
-        tasks: SAMPLE_TASKS.filter(task => !task.completed),
-      },
-    },
-  },
-];
 
 const TASKS_QUERY = gql`
   query TasksQuery {
@@ -89,6 +19,22 @@ const TASKS_QUERY = gql`
       id
       text
       completed
+    }
+  }
+`;
+
+const GRAPQHL_ERROR_QUERY = gql`
+  query GrapqhlErrorQuery {
+    tasks {
+      guid
+    }
+  }
+`;
+
+const NETWORK_ERROR_QUERY = gql`
+  query NetworkErrorQuery {
+    tasks {
+      id
     }
   }
 `;
@@ -103,15 +49,50 @@ const FILTERED_TASKS_QUERY = gql`
   }
 `;
 
-const linkReturningError = new ApolloLink(
-  () =>
-    new Observable(observer => {
-      observer.error(new Error('Simulating network error'));
-    })
-);
+const TASKS_MOCKS: MockedResponse[] = [
+  {
+    request: { query: TASKS_QUERY, variables: {} },
+    result: {
+      data: { __typename: 'Query', tasks: [...SAMPLE_TASKS] },
+    },
+  },
 
-function createMockClient(link?: ApolloLink) {
-  return createClient({ link, mocks: TASKS_MOCKS });
+  {
+    request: { query: GRAPQHL_ERROR_QUERY, variables: {} },
+    result: {
+      data: { __typename: 'Query' },
+      errors: [new GraphQLError('Simulating GraphQL error')],
+    },
+  },
+
+  {
+    error: new Error('Simulating network error'),
+    request: { query: NETWORK_ERROR_QUERY, variables: {} },
+  },
+
+  {
+    request: { query: FILTERED_TASKS_QUERY, variables: { completed: true } },
+    result: {
+      data: {
+        __typename: 'Query',
+        tasks: SAMPLE_TASKS.filter(task => task.completed),
+      },
+    },
+  },
+
+  {
+    request: { query: FILTERED_TASKS_QUERY, variables: { completed: false } },
+    result: {
+      data: {
+        __typename: 'Query',
+        tasks: SAMPLE_TASKS.filter(task => !task.completed),
+      },
+    },
+  },
+];
+
+function createMockClient() {
+  return createClient({ mocks: TASKS_MOCKS });
 }
 
 interface TasksProps<TVariables = any> extends QueryHookOptions<TVariables> {
@@ -129,20 +110,10 @@ function TaskList({ tasks }: { tasks: Array<{ id: number; text: string }> }) {
 }
 
 function Tasks({ query, ...options }: TasksProps) {
-  const { data, error, errors, loading } = useQuery(query, options);
+  const { data, error, loading } = useQuery(query, options);
 
   if (error) {
     return <>{error.message}</>;
-  }
-
-  if (errors) {
-    return (
-      <>
-        {errors.map(x => (
-          <Fragment key={x.message}>{x.message}</Fragment>
-        ))}
-      </>
-    );
   }
 
   if (loading) {
@@ -420,54 +391,6 @@ it("shouldn't allow a query with non-standard fetch policy with suspense", async
   expect(consoleErrorMock).toBeCalled();
 
   consoleErrorMock.mockRestore();
-});
-
-it("shouldn't ignore apollo errors in non-suspense mode", async () => {
-  const client = createMockClient(linkReturningError);
-  const { container } = render(
-    <TasksWrapper client={client} query={TASKS_QUERY} />
-  );
-
-  expect(container).toMatchInlineSnapshot(`
-<div>
-  Loading
-</div>
-`);
-
-  await flushEffectsAndWait();
-
-  expect(container).toMatchInlineSnapshot(`
-<div>
-  Network error: Simulating network error
-</div>
-`);
-});
-
-it('should ignore apollo errors by default in non-suspense mode', async () => {
-  const client = createMockClient(linkReturningError);
-  const consoleLogMock = jest.spyOn(console, 'error').mockImplementation(noop);
-
-  const { container } = render(
-    <TasksWrapper client={client} suspend={false} query={TASKS_QUERY} />
-  );
-
-  expect(container).toMatchInlineSnapshot(`
-<div>
-  Loading without suspense
-</div>
-`);
-
-  expect(consoleLogMock).toBeCalledTimes(0);
-
-  await flushEffectsAndWait();
-
-  expect(container).toMatchInlineSnapshot(`
-<div>
-  Network error: Simulating network error
-</div>
-`);
-
-  consoleLogMock.mockRestore();
 });
 
 it('should allow a query with non-standard fetch policy without suspense', async () => {
@@ -749,6 +672,89 @@ it('starts skipped query in non-suspense mode', async () => {
       Learn Apollo
     </li>
   </ul>
+</div>
+`);
+});
+
+it('handles network error in suspense mode', async () => {
+  const client = createMockClient();
+  const { container } = render(
+    <TasksWrapper suspend client={client} query={NETWORK_ERROR_QUERY} />
+  );
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  Loading
+</div>
+`);
+
+  await flushEffectsAndWait();
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  Network error: Simulating network error
+</div>
+`);
+});
+
+it('handles network error in non-suspense mode', async () => {
+  const client = createMockClient();
+  const { container } = render(
+    <TasksWrapper suspend={false} client={client} query={NETWORK_ERROR_QUERY} />
+  );
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  Loading without suspense
+</div>
+`);
+  await flushEffectsAndWait();
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  Network error: Simulating network error
+</div>
+`);
+});
+
+it('handles GraphQL error in suspense mode', async () => {
+  const client = createMockClient();
+  const { container } = render(
+    <TasksWrapper suspend client={client} query={GRAPQHL_ERROR_QUERY} />
+  );
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  Loading
+</div>
+`);
+
+  await flushEffectsAndWait();
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  GraphQL error: Simulating GraphQL error
+</div>
+`);
+});
+
+it('handles GraphQL error in non-suspense mode', async () => {
+  const client = createMockClient();
+  const { container } = render(
+    <TasksWrapper suspend={false} client={client} query={GRAPQHL_ERROR_QUERY} />
+  );
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  Loading without suspense
+</div>
+`);
+
+  await flushEffectsAndWait();
+
+  expect(container).toMatchInlineSnapshot(`
+<div>
+  GraphQL error: Simulating GraphQL error
 </div>
 `);
 });

--- a/src/__tests__/useQuery-test.tsx
+++ b/src/__tests__/useQuery-test.tsx
@@ -461,8 +461,7 @@ it("shouldn't make obsolete renders in suspense mode", async () => {
 </div>
 `);
 
-  // TODO: check why
-  expect(TasksWrapperWithProfiler).toHaveCommittedTimes(2);
+  expect(TasksWrapperWithProfiler).toHaveCommittedTimes(1);
 
   rerender(
     <TasksWrapperWithProfiler

--- a/src/__tests__/useQuery-test.tsx
+++ b/src/__tests__/useQuery-test.tsx
@@ -461,7 +461,8 @@ it("shouldn't make obsolete renders in suspense mode", async () => {
 </div>
 `);
 
-  expect(TasksWrapperWithProfiler).toHaveCommittedTimes(1);
+  // TODO: Find out why.
+  expect(TasksWrapperWithProfiler).toHaveCommittedTimes(2);
 
   rerender(
     <TasksWrapperWithProfiler

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -128,8 +128,9 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
       return {
         data: result.data as TData,
         error:
-          result.error ||
-          (result.errors && new ApolloError({ graphQLErrors: result.errors })),
+          result.errors && result.errors.length > 0
+            ? new ApolloError({ graphQLErrors: result.errors })
+            : result.error,
         loading: result.loading,
         partial: result.partial,
       };

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -1,5 +1,6 @@
 import {
   ApolloCurrentResult,
+  ApolloError,
   ApolloQueryResult,
   FetchMoreOptions,
   FetchMoreQueryOptions,
@@ -22,7 +23,7 @@ import { Omit, objToKey } from './utils';
 export interface QueryHookState<TData>
   extends Pick<
     ApolloCurrentResult<undefined | TData>,
-    'error' | 'errors' | 'loading' | 'partial'
+    'error' | 'loading' | 'partial'
   > {
   data?: TData;
 }
@@ -126,8 +127,9 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
 
       return {
         data: result.data as TData,
-        error: result.error,
-        errors: result.errors,
+        error:
+          result.error ||
+          (result.errors && new ApolloError({ graphQLErrors: result.errors })),
         loading: result.loading,
         partial: result.partial,
       };

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -23,7 +23,7 @@ import { Omit, objToKey } from './utils';
 export interface QueryHookState<TData>
   extends Pick<
     ApolloCurrentResult<undefined | TData>,
-    'error' | 'loading' | 'partial'
+    'error' | 'errors' | 'loading' | 'partial'
   > {
   data?: TData;
 }
@@ -131,6 +131,7 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
           result.errors && result.errors.length > 0
             ? new ApolloError({ graphQLErrors: result.errors })
             : result.error,
+        errors: result.errors,
         loading: result.loading,
         partial: result.partial,
       };


### PR DESCRIPTION
Implementation adopted from react Apollos [Query](https://github.com/apollographql/react-apollo/blob/62de2074fe01cde5d21dbfc582c5bb87c2011a36/src/Query.tsx#L389-L395). ~~Because of #28 already is a breaking change, I decided to remove `errors`.~~
Closes #34.
