### PR TITLE
Fix #59 - Create new observableQuery when cached instance torn down

### DIFF
--- a/src/queryCache.ts
+++ b/src/queryCache.ts
@@ -18,7 +18,7 @@ export function getCachedObservableQuery<TData, TVariables>(
   const queriesForClient = getCachedQueriesForClient(client);
   const cacheKey = getCacheKey(options);
   let observableQuery = queriesForClient.get(cacheKey);
-  if (observableQuery == null) {
+  if (observableQuery == null || observableQuery.isTornDown) {
     observableQuery = client.watchQuery(options);
     queriesForClient.set(cacheKey, observableQuery);
   }


### PR DESCRIPTION
Need to create a new observableQuery if the cached one is already torn down.