### PR TITLE
Fix #59 - notifyOnNetworkStatusChange default to false

### DIFF
--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -60,7 +60,7 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
 
     // Watch options
     pollInterval,
-    notifyOnNetworkStatusChange,
+    notifyOnNetworkStatusChange = false,
 
     // Apollo client options
     context,


### PR DESCRIPTION
ApolloClient QueryManager mutates the watchQueryOptions passed in to `client.watchQuery()` and makes `notifyOnNetworkStatusChange` false if it is undefined. This breaks the query caching mechanism because `invalidateCachedObservableQuery()` is called with this mutated watchQueryOptions and so the cache key for options changes from `"{}"` to `"{notifyOnNetworkStatusChange: false}"` and the stale observableQuery is never removed from the cache.

Alternate solution would be to make a copy of the options before passing them in `client.watchQuery`

https://github.com/apollographql/apollo-client/blob/3510493a2398f79bf193ab7579bbda87081cffcc/packages/apollo-client/src/core/QueryManager.ts#L658