### PR TITLE
feat(getMarkupFromTree): Add `onBeforeRender` handler.

### DIFF
--- a/src/getMarkupFromTree.tsx
+++ b/src/getMarkupFromTree.tsx
@@ -4,17 +4,23 @@ import { isPromiseLike } from './utils';
 
 export interface GetMarkupFromTreeOptions {
   tree: React.ReactNode;
+  onBeforeRender?: () => void;
   renderFunction: (tree: React.ReactElement<object>) => string;
 }
 
 export function getMarkupFromTree({
   tree,
+  onBeforeRender,
   renderFunction,
 }: GetMarkupFromTreeOptions): Promise<string> {
   const ssrManager = createSSRManager();
 
   function process(): string | Promise<string> {
     try {
+      if (onBeforeRender) {
+        onBeforeRender();
+      }
+
       const html = renderFunction(
         <SSRContext.Provider value={ssrManager}>{tree}</SSRContext.Provider>
       );


### PR DESCRIPTION
Usage of `getMarkupFromTree` create duplicates in some React libs like [react-head](https://github.com/tizmagik/react-head).

```js
const headTags = [];

const app = await getMarkupFromTree({
  onBeforeRender: () => {
    // Clear tags before each render.
    headTags.splice(0, headTags.length);
  },
  renderFunction: renderToString,
  tree: (
    <HeadProvider headTags={headTags}>
      <App />
    </HeadProvider>
  )
});
```