### PR TITLE
remove hooks warning from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 Use [Apollo Client](https://github.com/apollographql/apollo-client) as React
 [hooks](https://reactjs.org/docs/hooks-intro.html).
 
-_Warning: Hooks are currently a React
-[RFC](https://github.com/reactjs/rfcs/pull/68) and **not ready for production**.
-Use at minimum `react@16.8.0-alpha.1` to use this package._
-
 [![CircleCI](https://circleci.com/gh/trojanowski/react-apollo-hooks.svg?style=svg)](https://circleci.com/gh/trojanowski/react-apollo-hooks)
 
 # Installation


### PR DESCRIPTION
React hooks are in [stable version 16.8.0](https://github.com/facebook/react/blob/master/CHANGELOG.md#1680-february-6-2019)