### PR TITLE
Compact watchQueryOptions

### DIFF
--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -1,0 +1,8 @@
+import { compact } from '../utils';
+
+describe('compact', () => {
+  it('returns a new object omitting any keys with an undefined value', () => {
+    const compacted = compact({ a: 'value', b: 1, c: undefined });
+    expect(compacted.hasOwnProperty('c')).toBe(false);
+  });
+});

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -18,7 +18,7 @@ import {
   getCachedObservableQuery,
   invalidateCachedObservableQuery,
 } from './queryCache';
-import { Omit, objToKey } from './utils';
+import { Omit, compact, objToKey } from './utils';
 
 export interface QueryHookState<TData>
   extends Pick<
@@ -87,17 +87,18 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
       : actualCachePolicy;
 
   const watchQueryOptions: WatchQueryOptions<TVariables> = useMemo(
-    () => ({
-      context,
-      errorPolicy,
-      fetchPolicy,
-      fetchResults,
-      metadata,
-      notifyOnNetworkStatusChange,
-      pollInterval,
-      query,
-      variables,
-    }),
+    () =>
+      compact({
+        context,
+        errorPolicy,
+        fetchPolicy,
+        fetchResults,
+        metadata,
+        notifyOnNetworkStatusChange,
+        pollInterval,
+        query,
+        variables,
+      }),
     [
       query,
 
@@ -112,7 +113,6 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
       fetchResults,
     ]
   );
-
   const observableQuery = useMemo(
     () =>
       getCachedObservableQuery<TData, TVariables>(client, watchQueryOptions),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,16 @@ export function objToKey<T extends Record<string, any>>(obj: T): T | string {
 export function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
   return value != null && typeof (value as PromiseLike<T>).then === 'function';
 }
+
+export function compact(obj: any) {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      if (obj[key] !== undefined) {
+        acc[key] = obj[key];
+      }
+
+      return acc;
+    },
+    {} as any
+  );
+}


### PR DESCRIPTION
Options with undefined values shouldn't be passed to Apollo Client, otherwise they'll override any default options set on the client. This behavior is copied from React Apollo.

Fixes #76. I think this should be fixed upstream in Apollo Client, but this should get things working for now.