### PR TITLE
chore: update React peer dependency to ^16.8.0 (alternative)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "peerDependencies": {
     "apollo-client": "*",
     "graphql": "*",
-    "react": "^16.8.0-alpha.1"
+    "react": "^16.8.0"
   },
   "dependencies": {
     "lodash": "^4.17.11"
@@ -84,8 +84,8 @@
     "@types/graphql": "^14.0.3",
     "@types/jest": "^23.3.10",
     "@types/lodash": "^4.14.119",
-    "@types/react": "^16.7.17",
-    "@types/react-dom": "^16.0.11",
+    "@types/react": "^16.8.2",
+    "@types/react-dom": "^16.8.0",
     "apollo-cache-inmemory": "^1.3.11",
     "apollo-client": "^2.4.7",
     "apollo-link": "^1.2.4",
@@ -101,9 +101,9 @@
     "jest-react-profiler": "^0.1.3",
     "lint-staged": "^8.1.0",
     "prettier": "^1.15.2",
-    "react": "16.8.0-alpha.1",
-    "react-dom": "16.8.0-alpha.1",
-    "react-testing-library": "^5.3.1",
+    "react": "16.8.1",
+    "react-dom": "16.8.1",
+    "react-testing-library": "^5.5.3",
     "rimraf": "^2.6.2",
     "standard-version": "^4.4.0",
     "tslint": "^5.12.0",

--- a/src/__tests__/SuspenseSSR-test.tsx
+++ b/src/__tests__/SuspenseSSR-test.tsx
@@ -9,9 +9,11 @@ import { render } from 'react-testing-library';
 import { ApolloProvider } from '../ApolloContext';
 import { unstable_SuspenseSSR as SuspenseSSR } from '../SuspenseSSR';
 import createClient from '../__testutils__/createClient';
-import flushEffectsAndWait from '../__testutils__/flushEffectsAndWait';
+import wait from '../__testutils__/wait';
 import { getMarkupFromTree } from '../getMarkupFromTree';
 import { QueryHookOptions, useQuery } from '../useQuery';
+
+jest.mock('../internal/actHack');
 
 const USER_QUERY = gql`
   {
@@ -88,7 +90,7 @@ describe.each([[true], [false]])('SuspenseSSR with "suspend: %s"', suspend => {
 `);
     }
 
-    await flushEffectsAndWait();
+    await wait();
 
     expect(container).toMatchInlineSnapshot(`
 <div>

--- a/src/__tests__/getMarkupFromTree-test.tsx
+++ b/src/__tests__/getMarkupFromTree-test.tsx
@@ -16,6 +16,8 @@ import createClient from '../__testutils__/createClient';
 import { getMarkupFromTree } from '../getMarkupFromTree';
 import { QueryHookOptions, useQuery } from '../useQuery';
 
+jest.mock('../internal/actHack');
+
 const AUTH_QUERY = gql`
   {
     isAuthorized

--- a/src/__tests__/useMutation-test.tsx
+++ b/src/__tests__/useMutation-test.tsx
@@ -5,8 +5,10 @@ import { cleanup, fireEvent, render } from 'react-testing-library';
 import { ApolloProvider, useMutation, useQuery } from '..';
 import createClient from '../__testutils__/createClient';
 import { SAMPLE_TASKS } from '../__testutils__/data';
-import flushEffectsAndWait from '../__testutils__/flushEffectsAndWait';
 import noop from '../__testutils__/noop';
+import wait from '../__testutils__/wait';
+
+jest.mock('../internal/actHack');
 
 const TASKS_MOCKS = [
   {
@@ -182,7 +184,7 @@ it('should create a function to perform mutations', async () => {
     </ApolloProvider>
   );
 
-  await flushEffectsAndWait();
+  await wait();
 
   const firstCheckbox = container.querySelector<HTMLInputElement>(
     'input:checked'
@@ -190,7 +192,7 @@ it('should create a function to perform mutations', async () => {
   expect(firstCheckbox.checked).toBeTruthy();
 
   fireEvent.click(firstCheckbox);
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container.querySelector('input')!.checked).toBeFalsy();
 });
@@ -239,11 +241,11 @@ it('should allow to pass options forwarded to the mutation', async () => {
     </ApolloProvider>
   );
 
-  await flushEffectsAndWait();
+  await wait();
 
   const addTaskButton = getByTestId('add-task-button');
   fireEvent.click(addTaskButton);
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container.querySelectorAll('li')).toHaveLength(4);
   expect(container.querySelectorAll('li')[3].textContent).toBe('Learn Jest');

--- a/src/__tests__/useQuery-test.tsx
+++ b/src/__tests__/useQuery-test.tsx
@@ -10,8 +10,10 @@ import { GraphQLError } from 'graphql';
 import { ApolloProvider, QueryHookOptions, useQuery } from '..';
 import createClient from '../__testutils__/createClient';
 import { SAMPLE_TASKS } from '../__testutils__/data';
-import flushEffectsAndWait from '../__testutils__/flushEffectsAndWait';
 import noop from '../__testutils__/noop';
+import wait from '../__testutils__/wait';
+
+jest.mock('../internal/actHack');
 
 const TASKS_QUERY = gql`
   query TasksQuery {
@@ -159,7 +161,7 @@ it('should return the query data', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -190,7 +192,7 @@ it('should work with suspense disabled', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -225,7 +227,7 @@ it('should support query variables', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -254,7 +256,7 @@ it('should support updating query variables', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -288,8 +290,8 @@ it('should support updating query variables', async () => {
 `);
 
   // TODO: It doesn't pass if not invoked twice
-  await flushEffectsAndWait();
-  await flushEffectsAndWait();
+  await wait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -337,7 +339,7 @@ it("shouldn't suspend if the data is already cached", async () => {
     />
   );
 
-  await flushEffectsAndWait();
+  await wait();
 
   rerender(
     <TasksWrapper
@@ -347,7 +349,7 @@ it("shouldn't suspend if the data is already cached", async () => {
     />
   );
 
-  await flushEffectsAndWait();
+  await wait();
 
   rerender(
     <TasksWrapper
@@ -410,7 +412,7 @@ it('should allow a query with non-standard fetch policy without suspense', async
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -449,7 +451,7 @@ it("shouldn't make obsolete renders in suspense mode", async () => {
 
   expect(TasksWrapperWithProfiler).toHaveCommittedTimes(1);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -485,7 +487,7 @@ it("shouldn't make obsolete renders in suspense mode", async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -528,7 +530,7 @@ it("shouldn't make obsolete renders in suspense mode", async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(TasksWrapperWithProfiler).toHaveCommittedTimes(1);
 });
@@ -545,7 +547,7 @@ it('skips query in suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -566,7 +568,7 @@ it('skips query in non-suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -587,7 +589,7 @@ it('starts skipped query in suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -604,7 +606,7 @@ it('starts skipped query in suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -635,7 +637,7 @@ it('starts skipped query in non-suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -658,7 +660,7 @@ it('starts skipped query in non-suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -689,7 +691,7 @@ it('handles network error in suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -709,7 +711,7 @@ it('handles network error in non-suspense mode', async () => {
   Loading without suspense
 </div>
 `);
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -730,7 +732,7 @@ it('handles GraphQL error in suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>
@@ -751,7 +753,7 @@ it('handles GraphQL error in non-suspense mode', async () => {
 </div>
 `);
 
-  await flushEffectsAndWait();
+  await wait();
 
   expect(container).toMatchInlineSnapshot(`
 <div>

--- a/src/__testutils__/flushEffectsAndWait.ts
+++ b/src/__testutils__/flushEffectsAndWait.ts
@@ -1,9 +1,0 @@
-import { flushEffects } from 'react-testing-library';
-
-export default function flushEffectsAndWait(): Promise<void> {
-  return new Promise(resolve => {
-    flushEffects();
-
-    return setTimeout(resolve, 20);
-  });
-}

--- a/src/__testutils__/wait.ts
+++ b/src/__testutils__/wait.ts
@@ -1,0 +1,5 @@
+export default function wait(): Promise<void> {
+  return new Promise(resolve => {
+    return setTimeout(resolve, 10);
+  });
+}

--- a/src/internal/__mocks__/actHack.ts
+++ b/src/internal/__mocks__/actHack.ts
@@ -1,0 +1,3 @@
+import { act } from 'react-testing-library';
+
+export default act;

--- a/src/internal/actHack.ts
+++ b/src/internal/actHack.ts
@@ -1,0 +1,3 @@
+export default function actHack(callback: (() => void)) {
+  callback();
+}

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -14,6 +14,7 @@ import { DocumentNode } from 'graphql';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { useApolloClient } from './ApolloContext';
 import { SSRContext } from './internal/SSRContext';
+import actHack from './internal/actHack';
 import {
   getCachedObservableQuery,
   invalidateCachedObservableQuery,
@@ -145,7 +146,15 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
         return;
       }
 
-      const invalidateCurrentResult = () => setResponseId(x => x + 1);
+      const invalidateCurrentResult = () => {
+        // A hack to get rid React warnings during tests. The default
+        // implementation of `actHack` just invokes the callback immediately.
+        // In tests, it's replaced with `act` from react-testing-library.
+        // A better solution welcome.
+        actHack(() => {
+          setResponseId(x => x + 1);
+        });
+      };
       const subscription = observableQuery.subscribe(
         invalidateCurrentResult,
         invalidateCurrentResult

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,10 +648,10 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
-"@babel/runtime@^7.1.5":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
-  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
+"@babel/runtime@^7.1.5", "@babel/runtime@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -739,17 +739,17 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
   integrity sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==
 
-"@types/react-dom@^16.0.11":
-  version "16.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.11.tgz#bd10ccb0d9260343f4b9a49d4f7a8330a5c1f081"
-  integrity sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==
+"@types/react-dom@^16.8.0":
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.0.tgz#c565f43f9d2ec911f9e0b8f3b74e25e67879aa3f"
+  integrity sha512-Jp4ufcEEjVJEB0OHq2MCZcE1u3KYUKO6WnSuiU/tZeYeiZxUoQavfa/TZeiIT+1XoN6l0lQVNM30VINZFDeolQ==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.7.17":
-  version "16.7.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.18.tgz#f4ce0d539a893dd61e36cd11ae3a5e54f5a48337"
-  integrity sha512-Tx4uu3ppK53/iHk6VpamMP3f3ahfDLEVt3ZQc8TFm30a1H3v9lMsCntBREswZIW/SKrvJjkb3Hq8UwO6GREBng==
+"@types/react@*", "@types/react@^16.8.2":
+  version "16.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.2.tgz#3b7a7f7ea89d1c7d68b00849fb5de839011c077b"
+  integrity sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -4781,32 +4781,33 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.8.0-alpha.1:
-  version "16.8.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.0-alpha.1.tgz#dab73b8354ba2e498e3127d18e29d4546cea889e"
-  integrity sha512-tZCUM8BpnwUHJmLnUWP9c3vVZxnCqYotj7s4tx7umojG6BKv745KIBtuPTzt0EI0q50GMLEpmT/CPQ8iA61TwQ==
+react-dom@16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.1.tgz#ec860f98853d09d39bafd3a6f1e12389d283dbb4"
+  integrity sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.0-alpha.1"
+    scheduler "^0.13.1"
 
-react-testing-library@^5.3.1:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.4.2.tgz#0708ccf69b0df2c726b11ca5fcc0cb190a786897"
-  integrity sha512-1F4qd2vmRxtsz6o3vXFvxZb/QiHNpmjCFUAreom5h8yYPqbGQVIwlIaeGzg/QBoHreqeKGZ4VmqgepjQtoCWeA==
+react-testing-library@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.5.3.tgz#cfd32da95b29e475003df4f66bd96e34eb5624bd"
+  integrity sha512-67jMsSJHbbm9M0NWvEzjNikDAKRdxivhP6vnpa9xPg/fYh19zkE4rMsFh5YWLpyoomm+e49fg+ubcXaEBYartA==
   dependencies:
+    "@babel/runtime" "^7.3.1"
     dom-testing-library "^3.13.1"
 
-react@16.8.0-alpha.1:
-  version "16.8.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.0-alpha.1.tgz#c2b32689f3b466d3ce85a634dd9035f789d2cd97"
-  integrity sha512-vLwwnhM2dXrCsiQmcSxF2UdZVV5xsiXjK5Yetmy8dVqngJhQ3aw3YJhZN/YmyonxwdimH40wVqFQfsl4gSu2RA==
+react@16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"
+  integrity sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.0-alpha.1"
+    scheduler "^0.13.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -5159,10 +5160,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.0-alpha.1:
-  version "0.13.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.0-alpha.1.tgz#753977fb4fb35d8cdd559868a11e46b640955556"
-  integrity sha512-W0sH0848sVuPKg+I18vTYQyzVtA4X1lrVgSeXK6KnOPUltFdJcY5nkbTkjGUeS/E0x+eBsNYfSdhJtGjT95njw==
+scheduler@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.1.tgz#1a217df1bfaabaf4f1b92a9127d5d732d85a9591"
+  integrity sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
BREAKING CHANGE: minimum supported (and tested) version of React is now 16.8.0

Closes #71