### PR TITLE
useQuery->stale

### DIFF
--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -128,6 +128,7 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
 
   const currentResult = useMemo<QueryHookState<TData>>(
     () => {
+      const justLoadedFromCache = !observableQuery.lastResult;
       const result = observableQuery.currentResult();
 
       return {
@@ -143,7 +144,7 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
         // https://github.com/trojanowski/react-apollo-hooks/pull/68
         networkStatus: suspend ? undefined : result.networkStatus,
         partial: result.partial,
-        stale: result.stale
+        stale: result.data && (result.loading || justLoadedFromCache)
       };
     },
     [shouldSkip, responseId, observableQuery]

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -144,7 +144,7 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
         // https://github.com/trojanowski/react-apollo-hooks/pull/68
         networkStatus: suspend ? undefined : result.networkStatus,
         partial: result.partial,
-        stale: result.data && (result.loading || justLoadedFromCache)
+        stale: Object.keys(result.data).length > 0 && (result.loading || justLoadedFromCache)
       };
     },
     [shouldSkip, responseId, observableQuery]

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -25,7 +25,7 @@ import { Omit, compact, objToKey } from './utils';
 export interface QueryHookState<TData>
   extends Pick<
     ApolloCurrentResult<undefined | TData>,
-    'error' | 'errors' | 'loading' | 'partial'
+    'error' | 'errors' | 'loading' | 'partial' | 'stale'
   > {
   data?: TData;
   // networkStatus is undefined for skipped queries or the ones using suspense
@@ -142,6 +142,7 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
         // https://github.com/trojanowski/react-apollo-hooks/pull/68
         networkStatus: suspend ? undefined : result.networkStatus,
         partial: result.partial,
+        stale: result.stale
       };
     },
     [shouldSkip, responseId, observableQuery]

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -25,9 +25,10 @@ import { Omit, compact, objToKey } from './utils';
 export interface QueryHookState<TData>
   extends Pick<
     ApolloCurrentResult<undefined | TData>,
-    'error' | 'errors' | 'loading' | 'partial' | 'stale'
+    'error' | 'errors' | 'loading' | 'partial'
   > {
   data?: TData;
+  stale: boolean;
   // networkStatus is undefined for skipped queries or the ones using suspense
   networkStatus: NetworkStatus | undefined;
 }


### PR DESCRIPTION
Apollo doesn't seem to provide the `.stale` property on the `currentResult`, and it also returns false for `loading` on the first `currentResult` loaded from cache.