### PR TITLE
feat(useQuery): accept client option

### DIFF
--- a/src/ApolloContext.tsx
+++ b/src/ApolloContext.tsx
@@ -19,8 +19,17 @@ export function ApolloProvider<TCacheShape = any>({
   );
 }
 
-export function useApolloClient<TCache = object>(): ApolloClient<TCache> {
+export function useApolloClient<TCache = object>(
+  overrideClient?: ApolloClient<TCache>
+): ApolloClient<TCache> {
   const client = useContext(ApolloContext);
+
+  // Ensures that the number of hooks called from one render to another remains
+  // constant, despite the Apollo client read from context being swapped for
+  // one passed directly as prop.
+  if (overrideClient) {
+    return overrideClient;
+  }
 
   if (!client) {
     // https://github.com/apollographql/react-apollo/blob/5cb63b3625ce5e4a3d3e4ba132eaec2a38ef5d90/src/component-utils.tsx#L19-L22

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -1,4 +1,4 @@
-import {
+import ApolloClient, {
   ApolloCurrentResult,
   ApolloError,
   ApolloQueryResult,
@@ -32,12 +32,13 @@ export interface QueryHookState<TData>
   networkStatus: NetworkStatus | undefined;
 }
 
-export interface QueryHookOptions<TVariables>
+export interface QueryHookOptions<TVariables, TCache = object>
   extends Omit<QueryOptions<TVariables>, 'query'> {
   // watch query options from apollo client
   notifyOnNetworkStatusChange?: boolean;
   pollInterval?: number;
   // custom options of `useQuery` hook
+  client?: ApolloClient<TCache>;
   ssr?: boolean;
   skip?: boolean;
   suspend?: boolean;
@@ -55,7 +56,11 @@ export interface QueryHookResult<TData, TVariables>
   ): Promise<ApolloQueryResult<TData>>;
 }
 
-export function useQuery<TData = any, TVariables = OperationVariables>(
+export function useQuery<
+  TData = any,
+  TVariables = OperationVariables,
+  TCache = object
+>(
   query: DocumentNode,
   {
     // Hook options
@@ -68,15 +73,16 @@ export function useQuery<TData = any, TVariables = OperationVariables>(
     notifyOnNetworkStatusChange = false,
 
     // Apollo client options
+    client: overrideClient,
     context,
     metadata,
     variables,
     fetchPolicy: actualCachePolicy,
     errorPolicy,
     fetchResults,
-  }: QueryHookOptions<TVariables> = {}
+  }: QueryHookOptions<TVariables, TCache> = {}
 ): QueryHookResult<TData, TVariables> {
-  const client = useApolloClient();
+  const client = useApolloClient(overrideClient);
   const ssrManager = useContext(SSRContext);
   const ssrInUse = ssr && ssrManager;
 

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -20,9 +20,10 @@ export interface OnSubscriptionDataOptions<TData> {
   subscriptionData: SubscriptionHookResult<TData>;
 }
 
-export interface SubscriptionHookOptions<TData, TVariables>
+export interface SubscriptionHookOptions<TData, TVariables, TCache = object>
   extends Omit<SubscriptionOptions<TVariables>, 'query'> {
   onSubscriptionData?: OnSubscriptionData<TData>;
+  client?: ApolloClient<TCache>;
 }
 
 export interface SubscriptionHookResult<TData> {
@@ -31,14 +32,19 @@ export interface SubscriptionHookResult<TData> {
   loading: boolean;
 }
 
-export function useSubscription<TData = any, TVariables = OperationVariables>(
+export function useSubscription<
+  TData = any,
+  TVariables = OperationVariables,
+  TCache = object
+>(
   query: DocumentNode,
   {
     onSubscriptionData,
+    client: overrideClient,
     ...options
-  }: SubscriptionHookOptions<TData, TVariables> = {}
+  }: SubscriptionHookOptions<TData, TVariables, TCache> = {}
 ): SubscriptionHookResult<TData> {
-  const client = useApolloClient();
+  const client = useApolloClient(overrideClient);
   const onSubscriptionDataRef = useRef<
     OnSubscriptionData<TData> | null | undefined
   >(null);


### PR DESCRIPTION
Fixes #85.

I chose to preserve hooks invariants by still calling the `useApolloClient` hook despite the Apollo client being passed from the options.

I also implemented the same behaviour for `useMutation` and `useSubscription`.

This allows for creating custom hooks that address a specific client, e.g.:

```ts
function useBooksQuery(query, options) {
  const booksClient = useContext(BooksClientContext);
  return useQuery(query, { client: booksClient, ...options });
}
```