### PR TITLE
Use real `act` in tests

### DIFF
--- a/src/internal/actHack.ts
+++ b/src/internal/actHack.ts
@@ -1,8 +1,8 @@
-import { act } from 'react-dom/test-utils'
+import { act } from 'react-dom/test-utils';
 
 export default function actHack(callback: (() => void)) {
   if (process.env.NODE_ENV === 'test') {
-    act(callback)
+    act(callback);
   } else {
     callback();
   }

--- a/src/internal/actHack.ts
+++ b/src/internal/actHack.ts
@@ -1,3 +1,9 @@
+import { act } from 'react-dom/test-utils'
+
 export default function actHack(callback: (() => void)) {
-  callback();
+  if (process.env.NODE_ENV === 'test') {
+    act(callback)
+  } else {
+    callback();
+  }
 }

--- a/src/internal/actHack.ts
+++ b/src/internal/actHack.ts
@@ -1,6 +1,7 @@
 import { act } from 'react-dom/test-utils';
 
 export default function actHack(callback: (() => void)) {
+  // @ts-ignore process is not known
   if (process.env.NODE_ENV === 'test') {
     act(callback);
   } else {


### PR DESCRIPTION
The solution as outlined in https://github.com/trojanowski/react-apollo-hooks/issues/84#issuecomment-470288352

I am using it locally and it works nicely. I suppose that library tests could be updated and drop the mocking. However, given it's all temporary and with async `act` this may not be necessary anymore, I wouldn't really bother :)