### PR TITLE
Fix fallback of `data` attribute in query result

### DIFF
--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -27,7 +27,7 @@ export interface QueryHookState<TData>
     ApolloCurrentResult<undefined | TData>,
     'error' | 'errors' | 'loading' | 'partial'
   > {
-  data?: TData;
+  data: TData | {};
   // networkStatus is undefined for skipped queries or the ones using suspense
   networkStatus: NetworkStatus | undefined;
 }


### PR DESCRIPTION
Related to #127.

As described in https://www.apollographql.com/docs/react/essentials/queries#props, the `data` object is either the actual query result, or the empty object `{}` when the data is not (yet) available.

The type of `QueryHookResult` should match that.