### PR TITLE
useQueryLoader hook for reducing boilerplate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,46 @@ const MyComponent = () => {
 };
 ```
 
+## useQueryLoader
+
+If your logic to handle loading and error states is usually the same (and uses the same components to render these states), you can use the `useQueryLoader` hook to reduce boilerplate code. In order to use this hook, you'll first need to pass your components for rendering loading and error states to `ApolloProvider`:
+
+```javascript
+const Loader = () => <div>Loading...</div>;
+
+const ErrorMessage = ({ errorObject }) => (
+  <div>An error occurred: {errorObject.message}</div>
+);
+
+const App = () => (
+  <ApolloProvider
+    client={client}
+    defaultLoadingComponent={Loader}
+    defaultErrorComponent={ErrorMessage}
+  >
+    <MyRootComponent />
+  </ApolloProvider>
+);
+```
+
+Then in your components, `useQueryLoader` will take care of rendering loading and error states for you. You pass it a callback that renders data from successful query responses:
+
+```javascript
+const Dogs = () => {
+  return useQueryLoader(GET_DOGS)(({ data }) => (
+    <ul>
+      {data.dogs.map(dog => (
+        <li key={dog.id}>{dog.breed}</li>
+      ))}
+    </ul>
+  ));
+};
+```
+
+You can still of course use `useQuery` directly, for cases where you want to handle the loading or error state manually.
+
+Note that the `defaultLoadingComponent` should not have any required props, and `defaultErrorComponent` should be able to properly handle an `errorObject` prop that will be set to the GraphQL error returned by apollo-client.
+
 # Testing
 
 An example showing how to test components using react-apollo-hooks:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "url": "https://github.com/trojanowski/react-apollo-hooks.git"
   },
   "jest": {
+    "roots": [
+      "<rootDir>/src/"
+    ],
     "setupTestFrameworkScriptFile": "./src/__testutils__/setupTests.ts",
     "transform": {
       "^.+\\.(ts|tsx)$": "babel-jest"

--- a/src/ApolloContext.tsx
+++ b/src/ApolloContext.tsx
@@ -6,8 +6,8 @@ const ApolloContext = React.createContext<null | ApolloClient<any>>(null);
 export interface ApolloProviderProps<TCacheShape> {
   readonly children?: ReactNode;
   readonly client: ApolloClient<TCacheShape>;
-  defaultLoadingComponent?: React.ComponentType<any>;
-  defaultErrorComponent?: React.ComponentType<any>;
+  defaultLoadingComponent?: React.ComponentType<{}>;
+  defaultErrorComponent?: React.ComponentType<{ errorObject: Error }>;
 }
 
 const additionalOptionsMap = new WeakMap();

--- a/src/ApolloContext.tsx
+++ b/src/ApolloContext.tsx
@@ -6,17 +6,31 @@ const ApolloContext = React.createContext<null | ApolloClient<any>>(null);
 export interface ApolloProviderProps<TCacheShape> {
   readonly children?: ReactNode;
   readonly client: ApolloClient<TCacheShape>;
+  defaultLoadingComponent?: React.ComponentType<any>;
+  defaultErrorComponent?: React.ComponentType<any>;
 }
+
+const additionalOptionsMap = new WeakMap();
 
 export function ApolloProvider<TCacheShape = any>({
   client,
   children,
+  ...additionalOpts
 }: ApolloProviderProps<TCacheShape>): ReactElement<
   ApolloProviderProps<TCacheShape>
 > {
+  additionalOptionsMap.set(client, additionalOpts);
   return (
     <ApolloContext.Provider value={client}>{children}</ApolloContext.Provider>
   );
+}
+
+export function useReactApolloHooksOptions() {
+  const client = useContext(ApolloContext);
+  if (!client) {
+    throw new Error('Could not find "client" in the context');
+  }
+  return additionalOptionsMap.get(client);
 }
 
 export function useApolloClient<TCache = object>(

--- a/src/__tests__/useQueryLoader-test.tsx
+++ b/src/__tests__/useQueryLoader-test.tsx
@@ -1,0 +1,157 @@
+import { ApolloClient } from 'apollo-client';
+import { DocumentNode } from 'apollo-link';
+import { MockedResponse } from 'apollo-link-mock';
+import gql from 'graphql-tag';
+import React from 'react';
+import { cleanup, render } from 'react-testing-library';
+
+import { GraphQLError } from 'graphql';
+import { ApolloProvider, useQueryLoader } from '..';
+import createClient from '../__testutils__/createClient';
+import { SAMPLE_TASKS } from '../__testutils__/data';
+import wait from '../__testutils__/wait';
+
+jest.mock('../internal/actHack');
+
+const TASKS_QUERY = gql`
+  query TasksQuery {
+    tasks {
+      id
+      text
+      completed
+    }
+  }
+`;
+
+const GRAPQHL_ERROR_QUERY = gql`
+  query GrapqhlErrorQuery {
+    tasks {
+      guid
+    }
+  }
+`;
+
+const TASKS_MOCKS: MockedResponse[] = [
+  {
+    request: { query: TASKS_QUERY, variables: {} },
+    result: {
+      data: { __typename: 'Query', tasks: [...SAMPLE_TASKS] },
+    },
+  },
+  {
+    request: { query: GRAPQHL_ERROR_QUERY, variables: {} },
+    result: {
+      data: { __typename: 'Query' },
+      errors: [new GraphQLError('Simulating GraphQL error')],
+    },
+  },
+];
+
+function createMockClient() {
+  return createClient({ mocks: TASKS_MOCKS });
+}
+
+function Loader() {
+  return <>Loading</>;
+}
+
+function ErrorMessage({ errorObject }: { errorObject: Error }) {
+  return (
+    <>
+      <h3>Error</h3>
+      {errorObject.message}
+    </>
+  );
+}
+
+interface TasksProps {
+  query: DocumentNode;
+}
+
+function Tasks({ query }: TasksProps) {
+  return useQueryLoader(query)(({ data }) => {
+    const { tasks }: { tasks: Array<{ id: number; text: string }> } = data;
+    return (
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id}>{task.text}</li>
+        ))}
+      </ul>
+    );
+  });
+}
+
+interface TasksWrapperProps extends TasksProps {
+  client: ApolloClient<object>;
+}
+
+function TasksWrapper({ client, ...props }: TasksWrapperProps) {
+  return (
+    <ApolloProvider
+      client={client}
+      defaultLoadingComponent={Loader}
+      defaultErrorComponent={ErrorMessage}
+    >
+      <Tasks {...props} />
+    </ApolloProvider>
+  );
+}
+
+describe('useQueryLoader', () => {
+  afterEach(cleanup);
+
+  it('should return results of successful queries', async () => {
+    const client = createMockClient();
+    const { container } = render(
+      <TasksWrapper client={client} query={TASKS_QUERY} />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+<div>
+  Loading
+</div>
+`);
+
+    await wait();
+
+    expect(container).toMatchInlineSnapshot(`
+<div>
+  <ul>
+    <li>
+      Learn GraphQL
+    </li>
+    <li>
+      Learn React
+    </li>
+    <li>
+      Learn Apollo
+    </li>
+  </ul>
+</div>
+`);
+  });
+
+  it('should use the provided defaultErrorComponent', async () => {
+    const client = createMockClient();
+    const { container } = render(
+      <TasksWrapper client={client} query={GRAPQHL_ERROR_QUERY} />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+<div>
+  Loading
+</div>
+`);
+
+    await wait();
+
+    expect(container).toMatchInlineSnapshot(`
+<div>
+  <h3>
+    Error
+  </h3>
+  GraphQL error: Simulating GraphQL error
+</div>
+`);
+  });
+});

--- a/src/__tests__/useQueryLoader-test.tsx
+++ b/src/__tests__/useQueryLoader-test.tsx
@@ -111,7 +111,6 @@ describe('useQueryLoader', () => {
   Loading
 </div>
 `);
-
     await wait();
 
     expect(container).toMatchInlineSnapshot(`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './useQuery';
+export * from './useQueryLoader';
 export * from './useMutation';
 export * from './ApolloContext';
 export * from './SuspenseSSR';

--- a/src/useQueryLoader.tsx
+++ b/src/useQueryLoader.tsx
@@ -1,0 +1,65 @@
+import {
+  ApolloQueryResult,
+  FetchMoreOptions,
+  FetchMoreQueryOptions,
+  NetworkStatus,
+  ObservableQuery,
+  OperationVariables,
+} from 'apollo-client';
+import { DocumentNode } from 'graphql';
+import React from 'react';
+import { useReactApolloHooksOptions } from './ApolloContext';
+import { QueryHookOptions, QueryHookResult, useQuery } from './useQuery';
+
+export interface QueryLoaderResult<TData, TVariables>
+  extends Pick<
+    ObservableQuery<TData, TVariables>,
+    'refetch' | 'startPolling' | 'stopPolling' | 'updateQuery'
+  > {
+  data?: TData;
+  // networkStatus is undefined for skipped queries or the ones using suspense
+  networkStatus: NetworkStatus | undefined;
+  partial?: boolean;
+  fetchMore<K extends keyof TVariables>(
+    fetchMoreOptions: FetchMoreQueryOptions<TVariables, K> &
+      FetchMoreOptions<TData, TVariables>
+  ): Promise<ApolloQueryResult<TData>>;
+}
+
+type RenderCallback<TData, TVariables> = (
+  result: QueryLoaderResult<TData, TVariables>
+) => React.ReactElement<any> | null;
+
+export function useQueryLoader<
+  TData = any,
+  TVariables = OperationVariables,
+  TCache = object
+>(query: DocumentNode, options?: QueryHookOptions<TVariables, TCache>) {
+  const result = useQuery(query, options);
+  return (renderCallback: RenderCallback<TData, TVariables>) =>
+    render({ result, renderCallback });
+}
+
+export interface QueryLoaderProps {
+  result: QueryHookResult<any, any>;
+  renderCallback: RenderCallback<any, any>;
+}
+
+function render({ result, renderCallback }: QueryLoaderProps) {
+  const {
+    defaultLoadingComponent: LoadingComponent,
+    defaultErrorComponent: ErrorComponent,
+  } = useReactApolloHooksOptions();
+  if (!(LoadingComponent && ErrorComponent)) {
+    throw Error(
+      'defaultLoadingComponent and defaultErrorComponent must be set prior to using the useQueryLoader() hook'
+    );
+  }
+  if (result.loading) {
+    return <LoadingComponent />;
+  }
+  if (result.error) {
+    return <ErrorComponent errorObject={result.error} />;
+  }
+  return renderCallback(result);
+}


### PR DESCRIPTION
In the apps I have worked on, most components handle loading and error states in the same way. Prior to the advent of hooks, my team and I found it helpful to have a `QueryLoader` component that takes care of rendering loading and error states and wraps around react-apollo's `Query` component. This PR is my best effort to adapt this pattern to hooks.

Example usage:

```js
const App = () => (
  <ApolloProvider
    client={client}
    defaultLoadingComponent={Loader}
    defaultErrorComponent={ErrorMessage}
  >
    <MyRootComponent />
  </ApolloProvider>
);
...
const Dogs = () => {
  return useQueryLoader(GET_DOGS)(({ data }) => (
    <ul>
      {data.dogs.map(dog => (
        <li key={dog.id}>{dog.breed}</li>
      ))}
    </ul>
  ));
};
```

I think this use case is common enough that it's worth including in this library (and hopefully eventually in react-apollo itself one day). For configuring the default components for rendering loading and error states, I thought it made the most sense to pass them as props to `<ApolloProvider>`. (Another option would be to make them static public properties of `useQueryLoader`, but that would of course be less flexible.) In addition to serving a common use case, including `useQueryLoader` in this library also avoids the need for a second context/provider just for storing the default loading and error components.

A challenge here was that the `value` of `ApolloContext.Provider` is the `client`, and it didn't seem right to just tack on my `defaultLoadingComponent` and `defaultErrorComponent` properties onto the ApolloClient object. So I created a `WeakMap` for associating these additional options with the `client`...I'm open to alternative ideas.

Any feedback is welcome. Thank you!