### PR TITLE
Allow "cache-and-network" fetch policy with useQuery again

### DIFF
--- a/src/internal/actHack.ts
+++ b/src/internal/actHack.ts
@@ -1,3 +1,3 @@
-export default function actHack(callback: (() => void)) {
+export default function actHack(callback: () => void) {
   callback();
 }

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -4,11 +4,10 @@ import ApolloClient, {
   ApolloQueryResult,
   FetchMoreOptions,
   FetchMoreQueryOptions,
-  FetchPolicy,
   NetworkStatus,
   ObservableQuery,
   OperationVariables,
-  QueryOptions,
+  WatchQueryFetchPolicy,
   WatchQueryOptions,
 } from 'apollo-client';
 import { DocumentNode } from 'graphql';
@@ -33,7 +32,7 @@ export interface QueryHookState<TData>
 }
 
 export interface QueryHookOptions<TVariables, TCache = object>
-  extends Omit<QueryOptions<TVariables>, 'query'> {
+  extends Omit<WatchQueryOptions<TVariables>, 'query'> {
   // watch query options from apollo client
   notifyOnNetworkStatusChange?: boolean;
   pollInterval?: number;
@@ -230,7 +229,7 @@ export function useQuery<
 
 function ensureSupportedFetchPolicy(
   suspend: boolean,
-  fetchPolicy?: FetchPolicy
+  fetchPolicy?: WatchQueryFetchPolicy
 ) {
   if (suspend && fetchPolicy && fetchPolicy !== 'cache-first') {
     throw new Error(


### PR DESCRIPTION
In `apollo-client@2.6.0`, the `cache-and-network` fetch policy has been removed from the `FetchPolicy` type, as documented here: https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md#apollo-client-260-1

This results in type errors in any project that tries to use the `cache-and-network` fetch policy with `useQuery` using `apollo-client@2.6.0` (currently the latest release). To be clear, this very simple (valid!) use-case now results in a type error:

```js
const { data } = useQuery(gql`...`, {
  fetchPolicy: 'cache-and-network', // Type '"cache-and-network"' is not assignable to type '"cache-first" | "network-only" | "cache-only" | "no-cache" | "standby" | undefined'.
})
```

It also results in the following type errors in the project:

<details>
<summary>(7 type errors, click to expand...)</summary>

```
> react-apollo-hooks@0.4.5 typings-check /Users/harry/node_modules/react-apollo-hooks
> tsc --noEmit

node_modules/react-testing-library/typings/index.d.ts:13:46 - error TS2344: Type 'typeof import("/Users/harry/node_modules/react-apollo-hooks/node_modules/dom-testing-library/typings/queries")' does not satisfy the constraint 'Queries'.
  Property 'findByLabelText' is incompatible with index signature.
    Type 'FindByText' is not assignable to type 'Query'.
      Type 'Promise<HTMLElement>' is not assignable to type 'HTMLElement | HTMLElement[] | null'.
        Type 'Promise<HTMLElement>' is missing the following properties from type 'HTMLElement[]': length, pop, push, concat, and 26 more.

13 export type RenderResult<Q extends Queries = typeof queries> = {
                                                ~~~~~~~~~~~~~~

node_modules/react-testing-library/typings/index.d.ts:28:52 - error TS2344: Type 'typeof import("/Users/harry/node_modules/react-apollo-hooks/node_modules/dom-testing-library/typings/queries")' does not satisfy the constraint 'Queries'.

28 export interface RenderOptions<Q extends Queries = typeof queries> {
                                                      ~~~~~~~~~~~~~~

src/__tests__/getMarkupFromTree-test.tsx:163:15 - error TS2322: Type '"cache-and-network"' is not assignable to type '"no-cache" | "cache-first" | "network-only" | "cache-only" | "standby" | undefined'.

163               fetchPolicy="cache-and-network"
                  ~~~~~~~~~~~

  node_modules/apollo-client/core/watchQueryOptions.d.ts:18:5
    18     fetchPolicy?: FetchPolicy;
           ~~~~~~~~~~~
    The expected type comes from property 'fetchPolicy' which is declared here on type 'IntrinsicAttributes & UserWrapperProps'

src/__tests__/getMarkupFromTree-test.tsx:180:15 - error TS2322: Type '"cache-and-network"' is not assignable to type '"no-cache" | "cache-first" | "network-only" | "cache-only" | "standby" | undefined'.

180               fetchPolicy="cache-and-network"
                  ~~~~~~~~~~~

  node_modules/apollo-client/core/watchQueryOptions.d.ts:18:5
    18     fetchPolicy?: FetchPolicy;
           ~~~~~~~~~~~
    The expected type comes from property 'fetchPolicy' which is declared here on type 'IntrinsicAttributes & UserWrapperProps'

src/__tests__/useQuery-test.tsx:512:9 - error TS2322: Type '"cache-and-network"' is not assignable to type '"no-cache" | "cache-first" | "network-only" | "cache-only" | "standby" | undefined'.

512         fetchPolicy="cache-and-network"
            ~~~~~~~~~~~

  node_modules/apollo-client/core/watchQueryOptions.d.ts:18:5
    18     fetchPolicy?: FetchPolicy;
           ~~~~~~~~~~~
    The expected type comes from property 'fetchPolicy' which is declared here on type 'IntrinsicAttributes & TasksWrapperProps'

src/__tests__/useQuery-test.tsx:531:7 - error TS2322: Type '"cache-and-network"' is not assignable to type '"no-cache" | "cache-first" | "network-only" | "cache-only" | "standby" | undefined'.

531       fetchPolicy="cache-and-network"
          ~~~~~~~~~~~

  node_modules/apollo-client/core/watchQueryOptions.d.ts:18:5
    18     fetchPolicy?: FetchPolicy;
           ~~~~~~~~~~~
    The expected type comes from property 'fetchPolicy' which is declared here on type 'IntrinsicAttributes & TasksWrapperProps'

src/useQuery.ts:95:7 - error TS2367: This condition will always return 'false' since the types '"no-cache" | "cache-first" | "cache-only" | "standby" | undefined' and '"cache-and-network"' have no overlap.

95       actualCachePolicy === 'cache-and-network')
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 7 errors.
```

</details>

This issue has actually been reported here: https://github.com/apollographql/apollo-client/pull/4849

The fix is to simply change the `QueryOptions` type to `WatchQueryOptions`, as `useQuery` uses `watchQuery` (which allows the `cache-and-network` fetch policy), and not `query` (which doesn't).

This exact change is implemented in the commit https://github.com/trojanowski/react-apollo-hooks/commit/184a7b5a6cb13e99064409fc86ca359e12535bc1 (check this diff to look at the actual code changes!)

As a separate commit, I also ran `npm run format`. I initially did this to ensure that I did not introduce new style errors, but I actually found style errors in unrelated files. I hope this is not too controversial to add, if not I can revert/rebase.

When running `npm run check-typings`, I now only get 2 type errors, none of which are related to the fetch policy, and actually seem completely unrelated to the project:

<details>
<summary>(2 type errors, unrelated to this change, click to expand...)</summary>

```
> react-apollo-hooks@0.4.5 typings-check /Users/harry/node_modules/react-apollo-hooks
> tsc --noEmit

node_modules/react-testing-library/typings/index.d.ts:13:46 - error TS2344: Type 'typeof import("/Users/harry/node_modules/react-apollo-hooks/node_modules/dom-testing-library/typings/queries")' does not satisfy the constraint 'Queries'.
  Property 'findByLabelText' is incompatible with index signature.
    Type 'FindByText' is not assignable to type 'Query'.
      Type 'Promise<HTMLElement>' is not assignable to type 'HTMLElement | HTMLElement[] | null'.
        Type 'Promise<HTMLElement>' is missing the following properties from type 'HTMLElement[]': length, pop, push, concat, and 26 more.

13 export type RenderResult<Q extends Queries = typeof queries> = {
                                                ~~~~~~~~~~~~~~

node_modules/react-testing-library/typings/index.d.ts:28:52 - error TS2344: Type 'typeof import("/Users/harry/node_modules/react-apollo-hooks/node_modules/dom-testing-library/typings/queries")' does not satisfy the constraint 'Queries'.

28 export interface RenderOptions<Q extends Queries = typeof queries> {
                                                      ~~~~~~~~~~~~~~


Found 2 errors.
```

</details>

Anyway, hope this is useful for anyone who accidentally upgraded to `apollo-client@2.6.0` & broke their TypeScript projects! :)