### PR TITLE
Update useQuery to utilize WatchQueryOptions

### DIFF
--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -8,7 +8,6 @@ import ApolloClient, {
   NetworkStatus,
   ObservableQuery,
   OperationVariables,
-  QueryOptions,
   WatchQueryOptions,
 } from 'apollo-client';
 import { DocumentNode } from 'graphql';
@@ -33,7 +32,7 @@ export interface QueryHookState<TData>
 }
 
 export interface QueryHookOptions<TVariables, TCache = object>
-  extends Omit<QueryOptions<TVariables>, 'query'> {
+  extends Omit<WatchQueryOptions<TVariables>, 'query'> {
   // watch query options from apollo client
   notifyOnNetworkStatusChange?: boolean;
   pollInterval?: number;


### PR DESCRIPTION
It's more accurate this way, and a recent change has removed `cache-and-network` from the `fetchPolicy` values allowed in a plain old `QueryOptions` object, meaning that without this change, it's not possible to use `cache-and-network` with the `useQuery` hook.

Related change in Apollo Client: https://github.com/apollographql/apollo-client/commit/cf069bc7ee6577092234b0eb0ac32e05d50f5a1c#diff-88b34d7add139a9c0e7d4c2b1944a8dcR18