### PR TITLE
Removing the wrapper Promise in useMutation to enable apollo client stubs

### DIFF
--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -130,37 +130,36 @@ export function useMutation<TData, TVariables = OperationVariables>(
   };
 
   const runMutation = React.useCallback(
-    (mutateOptions: MutationHookOptions<TData, TVariables> = {}) => {
-      return new Promise<FetchResult<TData>>((resolve, reject) => {
-        onMutationStart();
-        const mutationId = generateNewMutationId();
+    (
+      mutateOptions: MutationHookOptions<TData, TVariables> = {}
+    ): Promise<FetchResult<TData>> => {
+      onMutationStart();
+      const mutationId = generateNewMutationId();
 
-        // merge together variables from baseOptions (if specified)
-        // and the execution
-        const mutateVariables = options.variables
-          ? { ...mutateOptions.variables, ...options.variables }
-          : mutateOptions.variables;
+      // merge together variables from baseOptions (if specified)
+      // and the execution
+      const mutateVariables = options.variables
+        ? { ...mutateOptions.variables, ...options.variables }
+        : mutateOptions.variables;
 
-        client
-          .mutate({
-            mutation,
-            ...options,
-            ...mutateOptions,
-            variables: mutateVariables,
-          })
-          .then(response => {
-            onMutationCompleted(response, mutationId);
-            resolve(response as ExecutionResult<TData>);
-          })
-          .catch(err => {
-            onMutationError(err, mutationId);
-            if (rethrow) {
-              reject(err);
-              return;
-            }
-            resolve(({} as unknown) as ExecutionResult<TData>);
-          });
-      });
+      return client
+        .mutate({
+          mutation,
+          ...options,
+          ...mutateOptions,
+          variables: mutateVariables,
+        })
+        .then(response => {
+          onMutationCompleted(response, mutationId);
+          return response as ExecutionResult<TData>;
+        })
+        .catch(err => {
+          onMutationError(err, mutationId);
+          if (rethrow) {
+            throw err;
+          }
+          return ({} as unknown) as ExecutionResult<TData>;
+        });
     },
     [client, mutation, objToKey(baseOptions)]
   );


### PR DESCRIPTION
Ohi there,

So, can i ask a favour? I support this apollo mocking library called [graphql-mock](https://github.com/MadRabbit/graphql-mock), which we use quite a bit in our work. It's sort like `nock` but for apollo. We're trying to migrate from vanilla `react-apollo` to your amazing `react-apollo-hooks`, but we've run into a bit of a problem with `useMutation`, which i hope we could address here.

Basically the way `graphql-mock` works is that it provides a mock apollo client which resolves queries and mutations immediately, so we could write tests without messing with async await. Here is an example https://github.com/MadRabbit/graphql-mock/blob/master/docs/mutations.md

The problem is though `react-apollo-hooks` wraps `client.mutate` queries in a new `Promise` wrapper, which prevents us from getting those immediate renders.

The funny thing is that `client.mutate` already returns a `Promise`, so if we shuffle things a little bit as in this PR, we both can get what we want. Your code will still work the same as before, and we can mess with the `client` methods unobstructed