### PR TITLE
Pass context from mutation call to onCompleted/onError handlers

### DIFF
--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -131,7 +131,7 @@ export function useMutation<TData, TVariables = OperationVariables>(
 
   const runMutation = React.useCallback(
     (
-      mutateOptions: MutationHookOptions<TData, TVariables> = {}, 
+      mutateOptions: MutationHookOptions<TData, TVariables> = {},
       context: TData | undefined
     ) => {
       return new Promise<FetchResult<TData>>((resolve, reject) => {

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -130,7 +130,10 @@ export function useMutation<TData, TVariables = OperationVariables>(
   };
 
   const runMutation = React.useCallback(
-    (mutateOptions: MutationHookOptions<TData, TVariables> = {}, context: TData | undefined) => {
+    (
+      mutateOptions: MutationHookOptions<TData, TVariables> = {}, 
+      context: TData | undefined
+    ) => {
       return new Promise<FetchResult<TData>>((resolve, reject) => {
         onMutationStart();
         const mutationId = generateNewMutationId();

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -130,7 +130,7 @@ export function useMutation<TData, TVariables = OperationVariables>(
   };
 
   const runMutation = React.useCallback(
-    (mutateOptions: MutationHookOptions<TData, TVariables> = {}) => {
+    (mutateOptions: MutationHookOptions<TData, TVariables> = {}, context: TData | undefined) => {
       return new Promise<FetchResult<TData>>((resolve, reject) => {
         onMutationStart();
         const mutationId = generateNewMutationId();
@@ -149,11 +149,11 @@ export function useMutation<TData, TVariables = OperationVariables>(
             variables: mutateVariables,
           })
           .then(response => {
-            onMutationCompleted(response, mutationId);
+            onMutationCompleted(response, mutationId, context);
             resolve(response as ExecutionResult<TData>);
           })
           .catch(err => {
-            onMutationError(err, mutationId);
+            onMutationError(err, mutationId, context);
             if (rethrow) {
               reject(err);
               return;


### PR DESCRIPTION
Is it possible to modify the hook implementation to allow access to context variables during mutation?

Is there a way I can do this without modifying the hook implementation?